### PR TITLE
Add rgdal import to hdf/DESCRIPTION

### DIFF
--- a/hdf/DESCRIPTION
+++ b/hdf/DESCRIPTION
@@ -5,5 +5,7 @@ Authors@R: "First Last <first.last@example.com> [aut, cre]"
 Description: What the package does (one paragraph)
 Depends:
     R (>= 3.1.0)
+Imports:
+    rgdal
 License: What license is it under?
 LazyData: true


### PR DESCRIPTION
Dear @odrans, 

R/hdf depends on rgdal.  To automate installation of the dependency, I have added it to the Imports section of DESCRIPTION.  Please merge!

Thanks
@jmuelmen
